### PR TITLE
Layout builder patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,10 @@
         "patches": {
             "drupal/focal_point": {
                 "Focal Point No Upscale": "https://www.drupal.org/files/issues/2020-05-19/focal_point-do_not_upscale-3048398-16.patch"     
+            },
+            
+            "drupal/layout_builder": {
+                "Reusable Block": "https://www.drupal.org/files/issues/2022-08-09/Add-reusable-option-to-inline-block-creation-2999491-93.patch"     
             }
         },
         "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
             },
             
             "drupal/core": {
-                "Reusable Block for Layout Builder": "https://www.drupal.org/files/issues/2022-08-09/Add-reusable-option-to-inline-block-creation-2999491-93.patch"     
+                "Reusable Block for Layout Builder": "https://www.drupal.org/files/issues/2022-04-06/2999491-82.patch"     
             }
         },
         "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -89,8 +89,8 @@
                 "Focal Point No Upscale": "https://www.drupal.org/files/issues/2020-05-19/focal_point-do_not_upscale-3048398-16.patch"     
             },
             
-            "drupal/layout_builder": {
-                "Reusable Block": "https://www.drupal.org/files/issues/2022-08-09/Add-reusable-option-to-inline-block-creation-2999491-93.patch"     
+            "drupal/core": {
+                "Reusable Block for Layout Builder": "https://www.drupal.org/files/issues/2022-08-09/Add-reusable-option-to-inline-block-creation-2999491-93.patch"     
             }
         },
         "installer-paths": {


### PR DESCRIPTION
Patch 82 for Layout Builder adds the functionality we need for reusable blocks.
There is a patch 92 and 93 that were added but break all functionality of layout builder. 
Those working on the project recommend using 82.

This closes Issue 62 in the theme repo: https://github.com/CuBoulder/tiamat-theme/issues/68 