### PR TITLE
CuBoulder/tiamat-theme#82 adds CU Boulder Campus News module

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -40,7 +40,7 @@ services:
       - mysql -uroot -e "CREATE DATABASE IF NOT EXISTS drupal9_test; GRANT ALL PRIVILEGES ON drupal9_test.* TO 'lamp'@'%' IDENTIFIED by 'lamp';"
 config:
   php: '8.0'
-  composer_version: '2.4.2'
+  composer_version: '2.4.4'
   webroot: .
   database: mariadb
   xdebug: false

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "cu-boulder/ucb_focal_image_enable": "dev-main",
         "cu-boulder/ucb_person_title": "dev-main",
         "cu-boulder/ucb_site_configuration": "dev-main",
+		"cu-boulder/ucb_campus_news": "dev-main",
         "cu-boulder/ucb_user_invite": "dev-main",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "cu-boulder/ucb_focal_image_enable": "dev-main",
         "cu-boulder/ucb_person_title": "dev-main",
         "cu-boulder/ucb_site_configuration": "dev-main",
-		"cu-boulder/ucb_campus_news": "dev-main",
+        "cu-boulder/ucb_campus_news": "dev-main",
         "cu-boulder/ucb_user_invite": "dev-main",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.0",


### PR DESCRIPTION
CuBoulder/tiamat-theme#82

Sister PR in: [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/20)

Authors: @patrickbrown-io @TeddyBearX

**IMPORTANT: An issue exists with an absent `Access-Control-Allow-Origin` header on the CU Boulder Today site API. This will cause the functionality to be broken. For testing select "Disable Cross-Origin Restrictions" or similar in your browser's developer tools.** 

Known issues: "Illegal choice" log messages (does not affect functionality)