### PR TITLE
Changes dependencies to reflect CKEditor 5 plugin work moving to the new `ucb_ckeditor_plugins` module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "cu-boulder/ucb_admin_menus": "dev-main",
         "cu-boulder/ucb_bootstrap_layouts": "dev-main",
         "cu-boulder/ucb_campus_news": "dev-main",
-        "cu-boulder/ucb_ck5_plugins": "dev-main",
+        "cu-boulder/ucb_ckeditor_plugins": "dev-main",
         "cu-boulder/ucb_d9_custom_entities": "dev-main",
         "cu-boulder/ucb_default_content": "dev-main",
         "cu-boulder/ucb_focal_image_enable": "dev-main",


### PR DESCRIPTION
CuBoulder/ucb_ckeditor_plugins#8

Sister PR in: [tiamat-profile](https://github.com/CuBoulder/tiamat-profile/pull/39), [tiamat10-project-template](https://github.com/CuBoulder/tiamat10-project-template/pull/1)